### PR TITLE
Fixed makefile adding flags to enable several file formats support

### DIFF
--- a/Makefile.vita.SDL2_image
+++ b/Makefile.vita.SDL2_image
@@ -19,7 +19,9 @@ COMMON_OBJS = IMG.o \
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 AR      = $(PREFIX)-gcc-ar
-CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2
+CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2 -DLOAD_BMP \
+				-DLOAD_GIF -DLOAD_LBM -DLOAD_PCX -DLOAD_PNM -DLOAD_TGA -DLOAD_XCF \
+				-DLOAD_XPM -DLOAD_XV -DLOAD_JPG -DLOAD_PNG
 ASFLAGS = $(CFLAGS)
 
 LIBS    += -lSDL2


### PR DESCRIPTION
Without providing the specific flags for enabling the desired file formats support, SDL_Image by default returns null trying to open any file format.

The proposed change enables all the file formats, as long as the final programs are compiled specifing to link the needed external libraries (e.g. libPNG for PNG file format, refer to the SDL2 documentation for the other formats).
Regards, nop90 